### PR TITLE
no more math for membership display

### DIFF
--- a/fobber.js
+++ b/fobber.js
@@ -67,11 +67,9 @@ function displayMembers(data){
     // update DOM with new fob events
     let div;
     if (data.total_door_access) {
-        const calc_vetted = data.total_vetted + data.total_free;
-        const calc_total = calc_vetted + data.total_not_vetted;
 
         div = document.createElement("div");
-        div.innerHTML = "Vetted: " + calc_vetted + "";
+        div.innerHTML = "Vetted: " + data.total_vetted + "";
         mainContainer.prepend(div);
 
         div = document.createElement("div");
@@ -79,7 +77,7 @@ function displayMembers(data){
         mainContainer.prepend(div);
 
         div = document.createElement("div");
-        div.innerHTML = "Total: " + calc_total + "";
+        div.innerHTML = "Total: " + data.total_membership + "";
         mainContainer.prepend(div);
 
     } else {


### PR DESCRIPTION
this PR changes display of total, regular and vetted members to use the raw numbers from the JSON instead of calculating them. We'll just use the raw values for `total_not_vetted` (Regular) , `total_vetted` (Vetted) and `total_membership` (Total):

```json
{
total_door_access: 192,
total_failed_payment: 0,
total_free: 4,
total_membership: 102,
total_need_onboarding: 0,
total_not_vetted: 45,
total_paused: 0,
total_vetted: 57
}
```